### PR TITLE
feat: Add detailed sidebar navigation for key Zoho apps

### DIFF
--- a/FutureHome/client/src/lib/navigation.ts
+++ b/FutureHome/client/src/lib/navigation.ts
@@ -1,12 +1,16 @@
-import { Home, Users, Briefcase, Mail, CheckSquare, BarChart2 } from 'lucide-react';
+import { Home, Users, Briefcase, Mail, CheckSquare, BarChart2, Book, LifeBuoy, GanttChart } from 'lucide-react';
 
 const crmNavigation = {
   sections: [
-    { title: 'Dashboard', icon: Home, items: ['Overview', 'Sales Analytics', 'Performance'] },
-    { title: 'Leads', icon: Users, items: ['All Leads', 'New Leads', 'Converted'] },
-    { title: 'Deals', icon: Briefcase, items: ['Pipeline', 'Closed Won', 'Closed Lost'] },
-    { title: 'Contacts', icon: Users, items: ['All Contacts', 'New Contacts'] },
-    { title: 'Reports', icon: BarChart2, items: ['Sales Reports', 'Lead Reports'] },
+    { title: 'Home', icon: Home, items: ['My Home', 'Dashboards'] },
+    { title: 'Leads', icon: Users, items: ['All Leads', 'New Leads', 'My Leads'] },
+    { title: 'Accounts', icon: Briefcase, items: ['All Accounts', 'My Accounts'] },
+    { title: 'Contacts', icon: Users, items: ['All Contacts', 'My Contacts'] },
+    { title: 'Deals', icon: Briefcase, items: ['All Deals', 'My Deals', 'Pipeline'] },
+    { title: 'Activities', icon: CheckSquare, items: ['Tasks', 'Events', 'Calls'] },
+    { title: 'Reports', icon: BarChart2, items: ['All Reports', 'My Reports'] },
+    { title: 'Forecasts', icon: BarChart2, items: [] },
+    { title: 'Campaigns', icon: BarChart2, items: [] },
   ],
 };
 
@@ -15,14 +19,44 @@ const mailNavigation = {
     { title: 'Inbox', icon: Mail, items: ['Primary', 'Social', 'Promotions'] },
     { title: 'Sent', icon: Mail, items: [] },
     { title: 'Drafts', icon: Mail, items: [] },
+    { title: 'Spam', icon: Mail, items: [] },
+    { title: 'Trash', icon: Mail, items: [] },
+    { title: 'Templates', icon: Mail, items: [] },
+    { title: 'Outbox', icon: Mail, items: [] },
   ],
 };
 
 const projectsNavigation = {
   sections: [
-    { title: 'Dashboard', icon: Home, items: ['My Overview', 'Team Overview'] },
-    { title: 'Projects', icon: Briefcase, items: ['All Projects', 'Active Projects', 'Completed'] },
-    { title: 'Tasks', icon: CheckSquare, items: ['My Tasks', 'All Tasks', 'Overdue'] },
+    { title: 'Dashboard', icon: Home, items: ['Project Overview', 'My Work'] },
+    { title: 'Tasks', icon: CheckSquare, items: ['All Tasks', 'My Tasks', 'Task Lists'] },
+    { title: 'Gantt Chart', icon: GanttChart, items: ['Project Timeline', 'Dependencies'] },
+    { title: 'Milestones', icon: Briefcase, items: [] },
+    { title: 'Timesheets', icon: Book, items: ['Log Time', 'My Timesheets'] },
+    { title: 'Issues', icon: LifeBuoy, items: ['All Issues', 'My Issues'] },
+    { title: 'Reports', icon: BarChart2, items: ['Task Reports', 'Project Reports'] },
+    { title: 'Users', icon: Users, items: [] },
+  ],
+};
+
+const booksNavigation = {
+  sections: [
+    { title: 'Dashboard', icon: Home, items: ['Main Dashboard', 'Financial Overview'] },
+    { title: 'Sales', icon: Briefcase, items: ['Estimates', 'Invoices', 'Payments Received'] },
+    { title: 'Purchases', icon: Briefcase, items: ['Bills', 'Expenses', 'Payments Made'] },
+    { title: 'Time Tracking', icon: Book, items: ['Projects', 'Timesheets'] },
+    { title: 'Accountant', icon: Book, items: ['Chart of Accounts', 'Manual Journals'] },
+    { title: 'Reports', icon: BarChart2, items: ['P&L', 'Balance Sheet', 'Cash Flow'] },
+  ],
+};
+
+const deskNavigation = {
+  sections: [
+    { title: 'Tickets', icon: LifeBuoy, items: ['All Tickets', 'My Tickets', 'New Ticket'] },
+    { title: 'Contacts', icon: Users, items: ['All Contacts', 'New Contact'] },
+    { title: 'Articles', icon: Book, items: ['Knowledge Base', 'New Article'] },
+    { title: 'Tasks', icon: CheckSquare, items: ['My Tasks', 'All Tasks'] },
+    { title: 'Reports', icon: BarChart2, items: ['Ticket Reports', 'Agent Reports'] },
   ],
 };
 
@@ -41,6 +75,10 @@ export function getAppNavigation(appName: string) {
       return mailNavigation;
     case 'Projects':
       return projectsNavigation;
+    case 'Books':
+      return booksNavigation;
+    case 'Desk':
+      return deskNavigation;
     default:
       return defaultNavigation;
   }


### PR DESCRIPTION
This commit populates the sidebar navigation with detailed, researched data for five key Zoho applications: CRM, Mail, Projects, Books, and Desk.

The `getAppNavigation` function in `navigation.ts` has been updated to return specific sections and page links for these applications, providing a more accurate and complete user experience in the sidebar. This builds upon the foundational UI work and is the first step in implementing the sidebars for all 92 applications.